### PR TITLE
Bug fixes for new panda version and for nodeTree none.

### DIFF
--- a/yabee_libs/egg_writer.py
+++ b/yabee_libs/egg_writer.py
@@ -1233,7 +1233,7 @@ def get_egg_materials_str(object_names=None):
                 elif nodeTree.links[0].to_node.name == 'Material Output':
                     print("INFO: {} is using for!".format(nodeTree.links[0].to_node.name)),
                     objects = bpy.context.selected_objects
-                    for node in bpy.data.materials[0].node_tree.nodes:
+                    for node in nodeTree.nodes:
                         if node.name == "Principled BSDF":
                             principled_bsdf = node
                             basecol = list(principled_bsdf.inputs["Base Color"].default_value)
@@ -1278,12 +1278,6 @@ def get_egg_materials_str(object_names=None):
                         mat_str += '  <Scalar> roughness { %s }\n' % STRF(mat.roughness)
                         mat_str += '  <Scalar> metallic { %s }\n' % STRF(mat.metallic)
                         mat_str += '  <Scalar> local { %s }\n' % STRF(0.0)
-
-        if TEXTURE_PROCESSOR == 'BAKE' and mat.use_nodes:
-            mat_str += '  <Scalar> diffr { 1.0 }\n'
-            mat_str += '  <Scalar> diffg { 1.0 }\n'
-            mat_str += '  <Scalar> diffb { 1.0 }\n'
-
         mat_str += '}\n\n'
 
     used_textures = {}


### PR DESCRIPTION
When exporting an  egg the material scalars 
  <Scalar> diffr { 1.0 }
  <Scalar> diffg { 1.0 }
  <Scalar> diffb { 1.0 }
  
  It causes the materials to not produce their colors. Once converted to bam, bam will strip this and the materials behave correctly. According to this thread, they are no longer supported.  Lets fix this at the egg level.
https://discourse.panda3d.org/t/understanding-materials-and-the-model-cache/29512/9
  

  
  Additionally, included is the fix we already talked about with a none exception.

