### PR TITLE
Custom Properties Tag Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ Exporting:
 - Materials and textures (Partially)
 - Armature (skeleton) animation
 - ShapeKeys (morph) animation
-- <Tag> and collision options export through Blender's "Game logic" -> "properties"
+- <Tag> and collision options export through Blender's "Object Properties" -> "Custom Properties"
 - Non cyclic NURBS Curves

--- a/yabee_libs/egg_writer.py
+++ b/yabee_libs/egg_writer.py
@@ -177,7 +177,8 @@ class Group:
                                % ('  ' * level, eggSafeName(self.object.yabee_name)))
                 
                 for key in self.object.keys():
-                     egg_str += f"<Tag> {key} {{{self.object[key]}}}\n"
+                     vals = ('  ' * level, key, self.object[key])
+                     egg_str += '%s  <Tag>  %s  { %s }\n' % vals
                 if self.object.ObjectType:
                     for val in self.object.ObjectType.split(','):
                         vals = ('  ' * level, val)

--- a/yabee_libs/egg_writer.py
+++ b/yabee_libs/egg_writer.py
@@ -175,6 +175,9 @@ class Group:
             else:
                 egg_str.append('%s<Group> %s {\n'\
                                % ('  ' * level, eggSafeName(self.object.yabee_name)))
+                
+                for key in self.object.keys():
+                     egg_str += f"<Tag> {key} {{{self.object[key]}}}\n"
                 if self.object.ObjectType:
                     for val in self.object.ObjectType.split(','):
                         vals = ('  ' * level, val)


### PR DESCRIPTION
Links blenders custom properties with the panda tag system. You can query the custom value properties as so:
`friction = panda_node.getTag("friction")
mass = panda_node.getTag("mass")
bounce = panda_node.getTag("bounce")
ghost = panda_node.getTag("ghost")`

You put the tabs on there in the custom properties fields in blender