### PR TITLE
Vertex Paint support code broken in Blender 3.6

### DIFF
--- a/yabee_libs/egg_writer.py
+++ b/yabee_libs/egg_writer.py
@@ -502,9 +502,10 @@ class EGGMeshObjectData(EGGBaseObjectData):
 
     def pre_convert_vtx_color(self):
         color_vtx_ref = []
-        if self.obj_ref.data.vertex_colors.active:
-            for col in self.obj_ref.data.vertex_colors.active.data:
-                color_vtx_ref.append(col.color)  # We have one color per data color
+        for f in self.obj_ref.data.polygons:
+         for v in f.vertices:
+            color = self.obj_ref.data.attributes["Color"].data[v].color
+            color_vtx_ref.append(color)  # We have one color per data color
         return color_vtx_ref
 
     def pre_calc_TBS(self):

--- a/yabee_libs/egg_writer.py
+++ b/yabee_libs/egg_writer.py
@@ -503,9 +503,9 @@ class EGGMeshObjectData(EGGBaseObjectData):
     def pre_convert_vtx_color(self):
         color_vtx_ref = []
         for f in self.obj_ref.data.polygons:
-         for v in f.vertices:
-            color = self.obj_ref.data.attributes["Color"].data[v].color
-            color_vtx_ref.append(color)  # We have one color per data color
+            for v in f.vertices:
+                color = self.obj_ref.data.attributes["Color"].data[v].color
+                color_vtx_ref.append(color)  # We have one color per data color
         return color_vtx_ref
 
     def pre_calc_TBS(self):


### PR DESCRIPTION
From what I could see this line will always return false, unless im missing something:
`if self.obj_ref.data.vertex_colors.active:`

the vertex_colors array is also empty for me. 

I am pretty sure the vertex colors got folded into attributes in newer versions of blender. At least from the uis perspective,so this would make sense the code changed to. Here is the ui:
![image](https://github.com/Maxwell175/YABEE/assets/53061890/7970e266-bf49-455d-8983-04e350e9b269)


This new code going to the attributes worked for me. Willing to take feedback.