### PR TITLE
fix matrix vector multiplication operator for NURBS curve export

### DIFF
--- a/yabee_libs/egg_writer.py
+++ b/yabee_libs/egg_writer.py
@@ -307,7 +307,7 @@ class EGGNurbsCurveObjectData(EGGBaseObjectData):
         idx = 0
         for spline in self.obj_ref.data.splines:
             for vtx in spline.points:
-                co = self.obj_ref.matrix_world * vtx.co
+                co = self.obj_ref.matrix_world @ vtx.co
                 fixed_co = tuple(map(lambda x: x * co[3], co[:3])) + (co[3],)
                 vertices.append('<Vertex> %i {\n  %s\n}\n' % (idx,
                                                               ' '.join(map(STRF, fixed_co))))


### PR DESCRIPTION
Blender apparently uses a @ operator for vector matrix multiplication in blender version 3. This is needed when exporting NURBS curves

sources:
https://blender.stackexchange.com/questions/129473/typeerror-element-wise-multiplication-not-supported-between-matrix-and-vect
https://peps.python.org/pep-0465/
